### PR TITLE
Add Dynamic Day/Night Cycle and 3D Canvas Fullscreen Mode

### DIFF
--- a/frontend/src/components/DigitalTwinDashboard.tsx
+++ b/frontend/src/components/DigitalTwinDashboard.tsx
@@ -387,27 +387,29 @@ export default function DigitalTwinDashboard() {
                   RUN {runMode ? "ON" : "OFF"}
                 </button>
               )}
-              <button
-                onClick={() => {
-                  toggleFullscreen().catch(() => {});
-                }}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 6,
-                  padding: "4px 10px",
-                  borderRadius: 6,
-                  background: isFullscreen ? "#FAC75A" : "rgba(7,25,82,0.6)",
-                  border: "1px solid rgba(151,254,237,0.3)",
-                  color: isFullscreen ? "#071952" : "#fff",
-                  fontSize: 9,
-                  fontWeight: 800,
-                  cursor: "pointer",
-                }}
-              >
-                {isFullscreen ? <Minimize size={12} /> : <Maximize size={12} />}
-                {isFullscreen ? "EXIT FULLSCREEN" : "FULLSCREEN"}
-              </button>
+              {!isLandscape && (
+                <button
+                  onClick={() => {
+                    toggleFullscreen().catch(() => {});
+                  }}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    padding: "4px 10px",
+                    borderRadius: 6,
+                    background: isFullscreen ? "#FAC75A" : "rgba(7,25,82,0.6)",
+                    border: "1px solid rgba(151,254,237,0.3)",
+                    color: isFullscreen ? "#071952" : "#fff",
+                    fontSize: 9,
+                    fontWeight: 800,
+                    cursor: "pointer",
+                  }}
+                >
+                  {isFullscreen ? <Minimize size={12} /> : <Maximize size={12} />}
+                  {isFullscreen ? "EXIT FULLSCREEN" : "FULLSCREEN"}
+                </button>
+              )}
               <button
                 onClick={toggleWalkMode}
                 style={{

--- a/frontend/src/components/DigitalTwinDashboard.tsx
+++ b/frontend/src/components/DigitalTwinDashboard.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { Canvas } from "@react-three/fiber";
 import * as THREE from "three";
-import { Navigation, Eye } from "lucide-react";
+import { Navigation, Eye, Maximize, Minimize } from "lucide-react";
 import {
   STABLE_INITIAL_ZONES,
   generateInitialZones,
@@ -387,6 +387,27 @@ export default function DigitalTwinDashboard() {
                   RUN {runMode ? "ON" : "OFF"}
                 </button>
               )}
+              <button
+                onClick={() => {
+                  toggleFullscreen().catch(() => {});
+                }}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: "4px 10px",
+                  borderRadius: 6,
+                  background: isFullscreen ? "#FAC75A" : "rgba(7,25,82,0.6)",
+                  border: "1px solid rgba(151,254,237,0.3)",
+                  color: isFullscreen ? "#071952" : "#fff",
+                  fontSize: 9,
+                  fontWeight: 800,
+                  cursor: "pointer",
+                }}
+              >
+                {isFullscreen ? <Minimize size={12} /> : <Maximize size={12} />}
+                {isFullscreen ? "EXIT FULLSCREEN" : "FULLSCREEN"}
+              </button>
               <button
                 onClick={toggleWalkMode}
                 style={{

--- a/frontend/src/components/dashboard/DashboardScene.tsx
+++ b/frontend/src/components/dashboard/DashboardScene.tsx
@@ -7,6 +7,7 @@ import CampusTrees from "../CampusTrees";
 import CampusFurniture from "../CampusFurniture";
 import Building from "./BuildingComponent";
 import FirstPersonController from "./FirstPersonController";
+import EnvironmentLighting from "./EnvironmentLighting";
 
 interface DashboardSceneProps {
   zones: Zone[];
@@ -27,29 +28,7 @@ export default function DashboardScene({
 }: DashboardSceneProps) {
   return (
     <>
-      <color attach="background" args={["#c0d4ee"]} />
-      <fog attach="fog" args={["#c0d4ee", 30, 70]} />
-
-      <ambientLight intensity={1.1} />
-      <directionalLight
-        position={[12, 20, 10]}
-        intensity={1.5}
-        castShadow
-        shadow-mapSize={[2048, 2048]}
-        shadow-bias={-0.0004}
-        shadow-camera-near={0.5}
-        shadow-camera-far={70}
-        shadow-camera-left={-25}
-        shadow-camera-right={25}
-        shadow-camera-top={25}
-        shadow-camera-bottom={-25}
-      />
-      <directionalLight
-        position={[-10, 12, -8]}
-        intensity={0.35}
-        color="#ddeeff"
-      />
-      <hemisphereLight args={["#c8daf0", "#3a7030", 0.5]} />
+      <EnvironmentLighting />
 
       <Ground />
       <Roads />

--- a/frontend/src/components/dashboard/EnvironmentLighting.tsx
+++ b/frontend/src/components/dashboard/EnvironmentLighting.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { Stars } from "@react-three/drei";
+
+export default function EnvironmentLighting() {
+  const [isNight, setIsNight] = useState(false);
+
+  useEffect(() => {
+    const checkTime = () => {
+      const currentHour = new Date().getHours();
+      // Night is from 18:00 (6 PM) to 5:59 AM (before 6 AM)
+      /*if (true) {
+        setIsNight(true);
+      }// debugging */
+      
+      if (currentHour >= 18 || currentHour < 6) {
+        setIsNight(true);
+      } else {
+        setIsNight(false);
+      }// */
+    };
+
+    // Check immediately
+    checkTime();
+
+    // Check every 1 minute so it updates instantly when testing
+    const interval = setInterval(checkTime, 10000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <>
+      {isNight ? (
+        <>
+          <color attach="background" args={["#121629"]} />
+          <fog attach="fog" args={["#121629", 25, 75]} />
+
+          <ambientLight intensity={0.5} color="#8090c0" />
+          
+          {/* Moon light */}
+          <directionalLight
+            position={[-15, 25, -15]}
+            intensity={0.8}
+            color="#cceeff"
+            castShadow
+            shadow-mapSize={[2048, 2048]}
+            shadow-bias={-0.0004}
+            shadow-camera-near={0.5}
+            shadow-camera-far={80}
+            shadow-camera-left={-30}
+            shadow-camera-right={30}
+            shadow-camera-top={30}
+            shadow-camera-bottom={-30}
+          />
+          
+          {/* Subdued fill light */}
+          <directionalLight
+            position={[10, 10, 10]}
+            intensity={0.3}
+            color="#6677aa"
+          />
+          
+          <hemisphereLight args={["#202a50", "#0a1020", 0.6]} />
+
+          <Stars radius={60} depth={50} count={3000} factor={4} saturation={0} fade speed={1} />
+        </>
+      ) : (
+        <>
+          <color attach="background" args={["#c0d4ee"]} />
+          <fog attach="fog" args={["#c0d4ee", 30, 70]} />
+
+          <ambientLight intensity={1.1} />
+
+          {/* Sun light */}
+          <directionalLight
+            position={[12, 20, 10]}
+            intensity={1.5}
+            castShadow
+            shadow-mapSize={[2048, 2048]}
+            shadow-bias={-0.0004}
+            shadow-camera-near={0.5}
+            shadow-camera-far={70}
+            shadow-camera-left={-25}
+            shadow-camera-right={25}
+            shadow-camera-top={25}
+            shadow-camera-bottom={-25}
+          />
+
+          <directionalLight
+            position={[-10, 12, -8]}
+            intensity={0.35}
+            color="#ddeeff"
+          />
+
+          <hemisphereLight args={["#c8daf0", "#3a7030", 0.5]} />
+        </>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/dashboard/EnvironmentLighting.tsx
+++ b/frontend/src/components/dashboard/EnvironmentLighting.tsx
@@ -4,7 +4,10 @@ import React, { useState, useEffect } from "react";
 import { Stars } from "@react-three/drei";
 
 export default function EnvironmentLighting() {
-  const [isNight, setIsNight] = useState(false);
+  const [isNight, setIsNight] = useState(() => {
+    const currentHour = new Date().getHours();
+    return currentHour >= 18 || currentHour < 6;
+  });
 
   useEffect(() => {
     const checkTime = () => {

--- a/frontend/src/components/dashboard/EnvironmentLighting.tsx
+++ b/frontend/src/components/dashboard/EnvironmentLighting.tsx
@@ -24,7 +24,7 @@ export default function EnvironmentLighting() {
     // Check immediately
     checkTime();
 
-    // Check every 1 minute so it updates instantly when testing
+    // Check every 10 seconds so it updates quickly when testing
     const interval = setInterval(checkTime, 10000);
     return () => clearInterval(interval);
   }, []);


### PR DESCRIPTION
This PR introduces two major UI/UX enhancements to the 3D Campus Digital Twin:
1. **Dynamic Day/Night Lighting Cycle**: Automatically switches the 3D environment's lighting between day and night based on the user's local system time.
2. **Fullscreen Mode for 3D Canvas**: Adds a dedicated toggle button to the 3D map toolbar, allowing users to view the campus in an immersive fullscreen mode.

### Changes
* **EnvironmentLighting Component:** 
  * Created `EnvironmentLighting.tsx` to modularize the lighting logic with minimal changes to the core `DashboardScene.tsx`.
  * The system checks the local time using a `setInterval` hook. If the time is between 6:00 PM and 5:59 AM, it renders the Night View.
  * **Night View Features:** Includes a dynamic starfield using `@react-three/drei` (`<Stars />`), a moonlight directional light, and a darker background/fog. Ambient and fill lights were specifically calibrated so that campus infrastructure (like roads) remains clearly visible in the dark.
* **Fullscreen Functionality:** 
  * Added a `FULLSCREEN` toggle button next to the First-Person View button in `DigitalTwinDashboard.tsx`.
  * Utilizes the native HTML5 Fullscreen API (`requestFullscreen`) to expand the `<section>` containing the `<Canvas>`, hiding the sidebar and header for maximum visibility.
  * Dynamically updates the button UI (Text and `Minimize`/`Maximize` Lucide icons) based on the current fullscreen state via a `fullscreenchange` event listener.

### 🔗 Related Issues
* Closes #38 
* Closes #39 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fullscreen toggle to the 3D scene toolbar with Maximize/Minimize icons.
  * Dynamic day/night lighting that automatically adjusts to local time, showing stars at night.

* **Refactor**
  * Consolidated environment lighting into a dedicated component for clearer scene composition and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->